### PR TITLE
add alternative script to only change the exisiting records

### DIFF
--- a/thinkfan/thinkfanHwmonUpdateNew.sh
+++ b/thinkfan/thinkfanHwmonUpdateNew.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+# parameters:
+THINKFAN_CONF="/etc/thinkfan.conf"
+
+
+# find the number of hwmon, e.g. "hwmon6"
+HWMONNUMBER=$(ls /sys/devices/platform/thinkpad_hwmon/hwmon)
+
+# replace "hwmon*" with the found HWMONNUMBER
+sed -i "s/\\/hwmon\\/hwmon./\\/hwmon\\/$HWMONNUMBER/g" "$THINKFAN_CONF"

--- a/thinkfan/thinkfanHwmonUpdateNew.sh
+++ b/thinkfan/thinkfanHwmonUpdateNew.sh
@@ -4,8 +4,8 @@
 THINKFAN_CONF="/etc/thinkfan.conf"
 
 
-# find the number of hwmon, e.g. "hwmon6"
-HWMONNUMBER=$(ls /sys/devices/platform/thinkpad_hwmon/hwmon)
+# find the number of hwmon, e.g. "hwmon6" -> 6
+HWMONNUMBER=$(ls /sys/devices/platform/thinkpad_hwmon/hwmon | grep -o '[0-9]')
 
-# replace "hwmon*" with the found HWMONNUMBER
-sed -i "s/\\/hwmon\\/hwmon./\\/hwmon\\/$HWMONNUMBER/g" "$THINKFAN_CONF"
+# replace with the found HWMONNUMBER
+sed -i "s/\\/hwmon\\/hwmon./\\/hwmon\\/hwmon$HWMONNUMBER/g" "$THINKFAN_CONF"

--- a/thinkfan/thinkfanHwmonUpdateNew.sh
+++ b/thinkfan/thinkfanHwmonUpdateNew.sh
@@ -5,7 +5,9 @@ THINKFAN_CONF="/etc/thinkfan.conf"
 
 
 # find the number of hwmon, e.g. "hwmon6" -> 6
-HWMONNUMBER=$(ls /sys/devices/platform/thinkpad_hwmon/hwmon | grep -o '[0-9]')
+HWMONNUMBER=$(ls /sys/devices/platform/thinkpad_hwmon/hwmon | grep -o '[0-9]\+')
 
 # replace with the found HWMONNUMBER
-sed -i "s/\\/hwmon\\/hwmon./\\/hwmon\\/hwmon$HWMONNUMBER/g" "$THINKFAN_CONF"
+sed -i "s|/hwmon/hwmon[0-9]\+|/hwmon/hwmon$HWMONNUMBER|g" "$THINKFAN_CONF"
+
+


### PR DESCRIPTION
the lines of the config-file don't change for me, so I got rid of that part of your script.

Another "advantage" (could maybe be a disadvantage to others):
My code does not find new or all temp_input files. In my case that is preferred, because otherwise one is found that is wrong. So I don't include that in my thinkfan.conf. Therefore it is never added.
